### PR TITLE
Keep device smoke portable across PowerShell hosts

### DIFF
--- a/scripts/device/run_termux_smoke.ps1
+++ b/scripts/device/run_termux_smoke.ps1
@@ -35,6 +35,28 @@ function Invoke-AdbAllowFail {
     & $Adb @AdbArgs @Args
 }
 
+function Get-Sha256Hex {
+    param([Parameter(Mandatory=$true)][string]$Path)
+
+    $cmd = Get-Command Get-FileHash -ErrorAction SilentlyContinue
+    if ($cmd) {
+        return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+    }
+
+    $stream = [System.IO.File]::OpenRead($Path)
+    try {
+        $sha256 = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $hash = $sha256.ComputeHash($stream)
+            return -join ($hash | ForEach-Object { $_.ToString("x2") })
+        } finally {
+            if ($sha256) { $sha256.Dispose() }
+        }
+    } finally {
+        $stream.Dispose()
+    }
+}
+
 function Get-DisplayState {
     $display = (& $Adb @AdbArgs shell "dumpsys display 2>/dev/null | grep 'Display State=' | head -1") -join "`n"
     if ($display -match "Display State=([A-Z]+)") { return $Matches[1] }
@@ -87,7 +109,7 @@ if (-not $DebPath) {
 if (-not (Test-Path -LiteralPath $DebPath)) { throw "Deb not found: $DebPath" }
 
 if ($ExpectedSha256) {
-    $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $DebPath).Hash.ToLowerInvariant()
+    $actual = Get-Sha256Hex -Path $DebPath
     if ($actual -ne $ExpectedSha256.ToLowerInvariant()) {
         throw "SHA256 mismatch. Expected $ExpectedSha256, got $actual"
     }


### PR DESCRIPTION
## Summary
- Add a .NET SHA256 fallback to the device smoke PowerShell wrapper.
- Keeps release-asset validation working when a maintainer launches the smoke script from a PowerShell host that does not expose `Get-FileHash`.

## Verification
- Parsed `scripts/device/run_termux_smoke.ps1` as a PowerShell scriptblock.
- `python scripts/ci/check_repo.py`
- `git diff --check`
- Full Termux tablet smoke against `release/flutter_3.44.0_aarch64.deb`:
  - `INSTALL_STATUS=0`
  - `POST_INSTALL_STATUS=0`
  - `FLUTTER_VERSION_STATUS=0`
  - `DART_VERSION_STATUS=0`
  - `DARTVM_VERSION_STATUS=0`
  - `DOCTOR_STATUS=0`
  - `CREATE_STATUS=0`
  - `BUILD_APK_STATUS=0`
  - `BUILD_LINUX_STATUS=0`
  - `DONE`

## Notes
- This is a wrapper-only CI/device-lab robustness fix; the `v3.44.0` release asset is unchanged.
