### PR TITLE
fix: correct engine.patch dependencies and files

### DIFF
--- a/patches/3.44.2/engine.patch
+++ b/patches/3.44.2/engine.patch
@@ -62,28 +62,8 @@ index 2b0d94e1a03..95c08f25c5d 100644
  
  # Sets default dependencies for executable and shared_library targets.
  #
-diff --git a/engine/src/build/config/android/config.gni b/engine/src/build/config/android/config.gni
-index 2ea3a3a59d6..3c32479760b 100644
---- a/engine/src/build/config/android/config.gni
-+++ b/engine/src/build/config/android/config.gni
-@@ -53,8 +53,13 @@ if (is_android) {
-   android_sdk = "${android_sdk_root}/platforms/android-${android_sdk_version}"
- 
-   # Path to the Android NDK and SDK.
--  android_ndk_version = "28.2.13676358"
--  android_ndk_root = "//flutter/third_party/android_tools/sdk/ndk/$android_ndk_version"
-+  declare_args() {
-+    android_ndk_version = "28.2.13676358"
-+  }
-+  declare_args() {
-+    android_ndk_root = "//flutter/third_party/android_tools/sdk/ndk/$android_ndk_version"
-+    android_clang_rt_version = "19"
-+  }
-   android_ndk_include_dir = "$android_ndk_root/usr/include"
- 
-   android_sdk = "${android_sdk_root}/platforms/android-${android_sdk_version}"
 diff --git a/engine/src/build/config/compiler/BUILD.gn b/engine/src/build/config/compiler/BUILD.gn
-index e06cf625abe..29dd9dde4a1 100644
+index e06cf625abe..33ec157159a 100644
 --- a/engine/src/build/config/compiler/BUILD.gn
 +++ b/engine/src/build/config/compiler/BUILD.gn
 @@ -651,7 +651,7 @@ config("runtime_library") {
@@ -114,12 +94,10 @@ index e06cf625abe..29dd9dde4a1 100644
    }
    if (!is_fuchsia && is_clang) {
 diff --git a/engine/src/build/config/sysroot.gni b/engine/src/build/config/sysroot.gni
-index 12c8df99f44..f50e332d429 100644
+index 12c8df99f44..5e87f79075c 100644
 --- a/engine/src/build/config/sysroot.gni
 +++ b/engine/src/build/config/sysroot.gni
-@@ -15,8 +15,10 @@ declare_args() {
-   use_default_linux_sysroot = true
- }
+@@ -17,6 +17,8 @@ declare_args() {
  
 -if (current_toolchain == default_toolchain && target_sysroot != "") {
 +if (!is_android && current_toolchain == default_toolchain && target_sysroot != "") {
@@ -129,20 +107,249 @@ index 12c8df99f44..f50e332d429 100644
  } else if (is_android) {
    import("//build/config/android/config.gni")
    sysroot = rebase_path("$android_toolchain_root/sysroot", root_build_dir)
-diff --git a/engine/src/flutter/shell/platform/linux/fl_accessible_text_field.cc b/engine/src/flutter/shell/platform/linux/fl_accessible_text_field.cc
-index 17d0a0d763d..bc1878501e2 100644
---- a/engine/src/flutter/shell/platform/linux/fl_accessible_text_field.cc
-+++ b/engine/src/flutter/shell/platform/linux/fl_accessible_text_field.cc
-@@ -6,7 +6,9 @@
- #include "flutter/shell/platform/linux/public/flutter_linux/fl_standard_message_codec.h"
- #include "flutter/shell/platform/linux/public/flutter_linux/fl_value.h"
- 
-+#if !PANGO_VERSION_CHECK(1, 44, 0)
- G_DEFINE_AUTOPTR_CLEANUP_FUNC(PangoContext, g_object_unref)
-+#endif
- // PangoLayout g_autoptr macro weren't added until 1.49.4. Add them manually.
- // https://gitlab.gnome.org/GNOME/pango/-/commit/0b84e14
- #if !PANGO_VERSION_CHECK(1, 49, 4)
+diff --git a/engine/src/build/config/termux/BUILD.gn b/engine/src/build/config/termux/BUILD.gn
+new file mode 100644
+index 00000000000..2503dc32083
+--- /dev/null
++++ b/engine/src/build/config/termux/BUILD.gn
+@@ -0,0 +1,179 @@
++import("//build/config/termux/termux.gni")
++import("//build/config/sysroot.gni")
++import("//build/config/profiler.gni")
++
++config("compiler") {
++  if (current_toolchain == "//build/toolchain/termux:${current_cpu}") {
++    cflags = [
++      "-fno-strict-aliasing",
++      "-fstack-protector",
++      "--param=ssp-buffer-size=8",
++      "-fPIC",
++      "-pipe",
++      "-fcolor-diagnostics",
++      "-ffunction-sections",
++      "-funwind-tables",
++      "-fno-short-enums",
++      "-nostdinc++",
++    ]
++    cflags_cc = ["-fvisibility-inlines-hidden"]
++    cflags_objcc = ["-fvisibility-inlines-hidden"]
++    ldflags = [
++      "-Wl,--fatal-warnings",
++      "-fPIC",
++      "-Wl,-z,noexecstack",
++      "-Wl,-z,now",
++      "-Wl,-z,relro",
++      "-Wl,--undefined-version",
++      "-Wl,--no-undefined",
++      "-Wl,--exclude-libs,ALL",
++      "-Wl,--icf=all",
++      "-Wl,-z,max-page-size=65536",
++    ]
++    defines = [
++      "__TERMUX__",
++      "HAVE_SYS_UIO_H"
++    ]
++    if (!using_sanitizer) {
++      ldflags += [ "-Wl,-z,defs" ]
++    }
++    if (enable_profiling && !is_debug) {
++      defines += [ "ENABLE_PROFILING" ]
++      cflags += [
++        "-fno-omit-frame-pointer",
++        "-mno-omit-leaf-frame-pointer",
++        "-g",
++      ]
++
++      if (enable_full_stack_frames_for_profiling) {
++        cflags += [
++          "-fno-inline",
++          "-fno-optimize-sibling-calls",
++        ]
++      }
++      ldflags += [ "-rdynamic" ]
++    }
++    if (using_sanitizer) {
++      cflags += [
++        "-fno-omit-frame-pointer",
++        "-gline-tables-only",
++      ]
++    }
++    if (is_asan) {
++      cflags += [ "-fsanitize=address" ]
++      ldflags += [ "-fsanitize=address" ]
++    }
++    if (is_lsan) {
++      cflags += [ "-fsanitize=leak" ]
++      ldflags += [ "-fsanitize=leak" ]
++    }
++    if (is_tsan) {
++      cflags += [ "-fsanitize=thread" ]
++      ldflags += [ "-fsanitize=thread" ]
++    }
++    if (is_msan) {
++      cflags += [ "-fsanitize=memory" ]
++      ldflags += [ "-fsanitize=memory" ]
++    }
++    if (is_ubsan) {
++      cflags += [ "-fsanitize=undefined" ]
++      ldflags += [ "-fsanitize=undefined" ]
++    }
++    if (current_cpu == "x64") {
++      cflags += [
++        "-m64",
++        "-march=x86-64",
++      ]
++      ldflags += [ "-m64" ]
++    } else if (current_cpu == "x86") {
++      cflags += [ "-m32" ]
++      ldflags += [ "-m32" ]
++      if (is_clang) {
++        cflags += [
++          "-mstack-alignment=16",
++          "-mstackrealign",
++        ]
++      }
++    } else if (current_cpu == "arm") {
++      cflags += [
++        "-march=$arm_arch",
++        "-mfloat-abi=$arm_float_abi",
++      ]
++      if (arm_tune != "") {
++        cflags += [ "-mtune=$arm_tune" ]
++      }
++      if (arm_use_thumb) {
++        cflags += [ "-mthumb" ]
++      }
++    }
++    if (current_cpu == "arm") {
++      cflags += [ "--target=arm-linux-androideabi${termux_api_level}" ]
++      ldflags += [ "--target=arm-linux-androideabi${termux_api_level}" ]
++    } else if (current_cpu == "arm64") {
++      cflags += [ "--target=aarch64-linux-android${termux_api_level}" ]
++      ldflags += [ "--target=aarch64-linux-android${termux_api_level}" ]
++    } else if (current_cpu == "x86") {
++      cflags += [ "--target=i686-linux-androideabi${termux_api_level}" ]
++      ldflags += [ "--target=i686-linux-androideabi${termux_api_level}" ]
++    } else if (current_cpu == "x64") {
++      cflags += [ "--target=x86_64-linux-androideabi${termux_api_level}" ]
++      ldflags += [ "--target=x86_64-linux-androideabi${termux_api_level}" ]
++    }
++    asmflags = cflags
++  } else {
++    configs = ["//build/config/compiler:compiler"]
++  }
++}
++
++config("runtime_library") {
++  if (current_toolchain == "//build/toolchain/termux:${current_cpu}") {
++    cflags_cc = ["-nostdinc++"]
++    cflags_objcc = [ "-nostdinc++" ]
++    defines = [
++      "__compiler_offsetof=__builtin_offsetof",
++      "nan=__builtin_nan"
++    ]
++    ldflags = [
++      "-stdlib=libstdc++",
++      "-Wl,--warn-shared-textrel"
++    ]
++    lib_dirs = [ "$custom_toolchain/lib/clang/18/lib/linux/" ]
++    include_dirs = [
++      "//flutter/third_party/libcxx/include",
++      "//flutter/third_party/libcxxabi/include",
++    ]
++  } else {
++    configs = ["//build/config/compiler:runtime_library"]
++  }
++}
++
++config("executable_ldconfig") {
++  if (current_toolchain == "//build/toolchain/termux:${current_cpu}") {
++    ldflags = [
++      "-Bdynamic",
++      "-Wl,-z,nocopyreloc",
++      "-Wl,--dynamic-linker=/system/bin/linker64",
++    ]
++  } else {
++    configs = ["//build/config/gcc:executable_ldconfig"]
++  }
++}
++
++# Termux SDK config — only apply sysroot/libs to target toolchain    
++config("sdk") {
++  if (current_toolchain == "//build/toolchain/termux:${current_cpu}") {
++    cflags = []
++    ldflags = [ "-Wl,-rpath=/data/data/com.termux/files/usr/lib" ]
++    libs = [ "log", "m" ]
++    lib_dirs = [ "$custom_toolchain/lib/clang/18/lib/linux/" ]
++    if (defined(target_sysroot) && target_sysroot != "") {
++      cflags += [ "--sysroot=" + target_sysroot ]
++      ldflags += [ "--sysroot=" + target_sysroot ]
++    }
++    if (defined(custom_sysroot) && custom_sysroot != "") {
++      cflags += [ "-idirafter$custom_sysroot/usr/include" ]
++      lib_dirs += [ "$custom_sysroot/usr/lib" ]
++    }
++  }
++}
++
+diff --git a/engine/src/build/config/termux/termux.gni b/engine/src/build/config/termux/termux.gni
+new file mode 100644
+index 00000000000..0d97976c4ac
+--- /dev/null
++++ b/engine/src/build/config/termux/termux.gni
+@@ -0,0 +1,6 @@
++declare_args() {
++  termux_api_level = 26
++
++  is_termux = false
++  is_termux_host = false
++}
+diff --git a/engine/src/build/toolchain/termux/BUILD.gn b/engine/src/build/toolchain/termux/BUILD.gn
+new file mode 100644
+index 00000000000..564c5829578
+--- /dev/null
++++ b/engine/src/build/toolchain/termux/BUILD.gn
+@@ -0,0 +1,40 @@
++import("//build/toolchain/gcc_toolchain.gni")
++import("//build/config/android/config.gni")
++import("//build/config/termux/termux.gni")
++import("//build/toolchain/custom/custom.gni")
++
++template("termux_toolchain") {
++  gcc_toolchain(target_name) {
++    assert(defined(custom_toolchain) && custom_toolchain != "")
++
++    is_clang = true
++    toolchain_os = "linux"
++    toolchain_cpu = invoker.toolchain_cpu
++
++    prefix = "$custom_toolchain/bin"
++    cc = prefix + "/clang"
++    cxx = prefix + "/clang++"
++    asm = prefix + "/clang"
++    ar = prefix + "/llvm-ar"
++    ld = prefix + "/clang++"
++    readelf = prefix + "/llvm-readelf"
++    nm = prefix + "/llvm-nm"
++    strip = prefix + "/llvm-strip"
++  }
++}
++
++termux_toolchain("arm64"){
++  toolchain_cpu = "arm64"
++}
++
++termux_toolchain("arm"){
++  toolchain_cpu = "arm"
++}
++
++termux_toolchain("x64"){
++  toolchain_cpu = "x64"
++}
++
++termux_toolchain("x86"){
++  toolchain_cpu = "x86"
++}
 diff --git a/engine/src/flutter/shell/testing/BUILD.gn b/engine/src/flutter/shell/testing/BUILD.gn
 index f97ae91ae83..a760ed12016 100644
 --- a/engine/src/flutter/shell/testing/BUILD.gn
@@ -172,99 +379,37 @@ index f97ae91ae83..a760ed12016 100644
    }
  
    metadata = {
-diff --git a/packages/flutter_tools/lib/src/artifacts.dart b/packages/flutter_tools/lib/src/artifacts.dart
-index 6d3f133c3ed..cfd42289819 100644
---- a/packages/flutter_tools/lib/src/artifacts.dart
-+++ b/packages/flutter_tools/lib/src/artifacts.dart
-@@ -929,7 +929,7 @@ TargetPlatform _currentHostPlatform(Platform platform, OperatingSystemUtils oper
-   if (platform.isMacOS) {
-     return TargetPlatform.darwin;
-   }
--  if (platform.isLinux) {
-+  if (platform.isLinux || platform.isAndroid) { // Termux: map Android host to Linux artifacts.
-     return switch (operatingSystemUtils.hostPlatform) {
-       HostPlatform.linux_x64 => TargetPlatform.linux_x64,
-       HostPlatform.linux_riscv64 => TargetPlatform.linux_riscv64,
-diff --git a/packages/flutter_tools/lib/src/build_info.dart b/packages/flutter_tools/lib/src/build_info.dart
-index 29ef12f7bb8..4edf30d6870 100644
---- a/packages/flutter_tools/lib/src/build_info.dart
-+++ b/packages/flutter_tools/lib/src/build_info.dart
-@@ -903,7 +903,7 @@ HostPlatform getCurrentHostPlatform() {
-       DarwinArch.armv7 => throw Exception('Unsupported macOS arch "amv7"'),
-     };
-   }
--  if (globals.platform.isLinux) {
-+  if (globals.platform.isLinux || globals.platform.isAndroid) { // Termux: Android host uses Linux artifacts.
-     // support x64 and arm64 architecture.
-     return globals.os.hostPlatform;
-   }
-diff --git a/packages/flutter_tools/lib/src/commands/build_aar.dart b/packages/flutter_tools/lib/src/commands/build_aar.dart
-index 67561f9ce10..a1f7b2ff16b 100644
---- a/packages/flutter_tools/lib/src/commands/build_aar.dart
-+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
-@@ -52,7 +52,7 @@ class BuildAarCommand extends BuildSubCommand {
-     addAndroidSpecificBuildOptions(hide: !verboseHelp);
-     argParser.addMultiOption(
-       'target-platform',
--      defaultsTo: <String>['android-arm', 'android-arm64', 'android-x64'],
-+      defaultsTo: <String>['android-arm64'],  // Modified for Termux ARM64
-       allowed: <String>['android-arm', 'android-arm64', 'android-x64'],
-       help: 'The target platform for which the project is compiled.',
-     );
-diff --git a/packages/flutter_tools/lib/src/commands/build_apk.dart b/packages/flutter_tools/lib/src/commands/build_apk.dart
-index 184a68be58d..04c3dc12de3 100644
---- a/packages/flutter_tools/lib/src/commands/build_apk.dart
-+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
-@@ -69,8 +69,11 @@ class BuildApkCommand extends BuildSubCommand {
-     return BuildMode.release;
-   }
+diff --git a/engine/src/build/config/android/config.gni b/engine/src/build/config/android/config.gni
+index 2ea3a3a59d6..8ebefc0be97 100644
+--- a/engine/src/build/config/android/config.gni
++++ b/engine/src/build/config/android/config.gni
+@@ -53,8 +53,13 @@ if (is_android) {
+   android_sdk = "${android_sdk_root}/platforms/android-${android_sdk_version}"
  
--  static const _kDefaultJitArchs = <String>['android-arm', 'android-arm64', 'android-x64'];
--  static const _kDefaultAotArchs = <String>['android-arm', 'android-arm64', 'android-x64'];
-+  // Modified for Termux ARM64: default to android-arm64 only
-+  // Original: ['android-arm', 'android-arm64', 'android-x64']
-+  // Reason: gen_snapshot for android-arm and android-x64 cannot be cross-compiled for ARM64 hosts
-+  static const _kDefaultJitArchs = <String>['android-arm64'];
-+  static const _kDefaultAotArchs = <String>['android-arm64'];
-   List<String> get _targetArchs => stringsArg('target-platform').isEmpty
-       ? switch (_buildMode) {
-           BuildMode.release || BuildMode.profile => _kDefaultAotArchs,
-diff --git a/packages/flutter_tools/lib/src/commands/build_appbundle.dart b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
-index af58cbe68fa..0117f99b11f 100644
---- a/packages/flutter_tools/lib/src/commands/build_appbundle.dart
-+++ b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
-@@ -40,7 +40,7 @@ class BuildAppBundleCommand extends BuildSubCommand {
-     addIgnoreDeprecationOption();
-     argParser.addMultiOption(
-       'target-platform',
--      defaultsTo: <String>['android-arm', 'android-arm64', 'android-x64'],
-+      defaultsTo: <String>['android-arm64'],  // Modified for Termux ARM64
-       allowed: <String>['android-arm', 'android-arm64', 'android-x64'],
-       help: 'The target platform for which the app is compiled.',
-     );
-diff --git a/packages/flutter_tools/lib/src/flutter_cache.dart b/packages/flutter_tools/lib/src/flutter_cache.dart
-index bf144dbc2a5..6f099da0e54 100644
---- a/packages/flutter_tools/lib/src/flutter_cache.dart
-+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
-@@ -783,7 +783,7 @@ class FontSubsetArtifacts extends EngineCachedArtifact {
-     if (cache.includeAllPlatforms) {
-       return artifacts.values.toList();
-     } else {
--      final List<String>? binaryDirs = artifacts[_platform.operatingSystem];
-+      final List<String>? binaryDirs = artifacts[_platform.isAndroid ? "linux" : _platform.operatingSystem]; // Termux: map Android host to Linux artifacts.
-       if (binaryDirs == null) {
-         throwToolExit('Unsupported operating system: ${_platform.operatingSystem}');
-       }
-diff --git a/packages/flutter_tools/lib/src/web/chrome.dart b/packages/flutter_tools/lib/src/web/chrome.dart
-index 2d41ab695f5..25dfac64ead 100644
---- a/packages/flutter_tools/lib/src/web/chrome.dart
-+++ b/packages/flutter_tools/lib/src/web/chrome.dart
-@@ -57,7 +57,7 @@ String findChromeExecutable(Platform platform, FileSystem fileSystem) {
-   if (platform.environment.containsKey(kChromeEnvironment)) {
-     return platform.environment[kChromeEnvironment]!;
-   }
--  if (platform.isLinux) {
-+  if (platform.isLinux || platform.isAndroid) { // Termux: use Linux Chrome lookup on Android host.
-     return kLinuxExecutable;
-   }
-   if (platform.isMacOS) {
+   # Path to the Android NDK and SDK.
+-  android_ndk_version = "28.2.13676358"
+-  android_ndk_root = "//flutter/third_party/android_tools/sdk/ndk/$android_ndk_version"
++  declare_args() {
++    android_ndk_version = "28.2.13676358"
++  }
++  declare_args() {
++    android_ndk_root = "//flutter/third_party/android_tools/sdk/ndk/$android_ndk_version"
++    android_clang_rt_version = "19"
++  }
+   android_ndk_include_dir = "$android_ndk_root/usr/include"
+ 
+   android_sdk = "${android_sdk_root}/platforms/android-${android_sdk_version}"
+diff --git a/engine/src/flutter/shell/platform/linux/fl_accessible_text_field.cc b/engine/src/flutter/shell/platform/linux/fl_accessible_text_field.cc
+index 17d0a0d763d..bc1878501e2 100644
+--- a/engine/src/flutter/shell/platform/linux/fl_accessible_text_field.cc
++++ b/engine/src/flutter/shell/platform/linux/fl_accessible_text_field.cc
+@@ -6,7 +6,9 @@
+ #include "flutter/shell/platform/linux/public/flutter_linux/fl_standard_message_codec.h"
+ #include "flutter/shell/platform/linux/public/flutter_linux/fl_value.h"
+ 
++#if !PANGO_VERSION_CHECK(1, 44, 0)
+ G_DEFINE_AUTOPTR_CLEANUP_FUNC(PangoContext, g_object_unref)
++#endif
+ // PangoLayout g_autoptr macro weren't added until 1.49.4. Add them manually.
+ // https://gitlab.gnome.org/GNOME/pango/-/commit/0b84e14
+ #if !PANGO_VERSION_CHECK(1, 49, 4)


### PR DESCRIPTION
Restores missing termux config/toolchain GN files and removes duplicated packages/flutter_tools hunks from patches/3.44.2/engine.patch as reported by the Codex PR AI Review.