### PR TITLE
 fix: pre-check toolchain check helper existence in setup_modern_tools.sh

### DIFF
--- a/scripts/install/setup_modern_tools.sh
+++ b/scripts/install/setup_modern_tools.sh
@@ -13,6 +13,17 @@ if ! command -v 7z &>/dev/null; then
     exit 1
 fi
 
+# Path discovery for check_toolchain.sh (Pre-run check)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+if [ -f "$SCRIPT_DIR/check_toolchain.sh" ]; then
+    CHECK_TOOLCHAIN_PATH="$SCRIPT_DIR/check_toolchain.sh"
+elif [ -f "$SCRIPT_DIR/../ci/check_toolchain.sh" ]; then
+    CHECK_TOOLCHAIN_PATH="$SCRIPT_DIR/../ci/check_toolchain.sh"
+else
+    echo "Error: check_toolchain.sh helper script not found. Please run within the standard Termux Flutter install tree." >&2
+    exit 1
+fi
+
 echo "=== Installing Pinned ARM64 Build-Tools (v$BUILD_TOOLS_VER) ==="
 mkdir -p "$TARGET_DIR"
 cd "$TARGET_DIR"
@@ -36,12 +47,6 @@ chmod +x "$AAPT2_BIN" "$SPLIT_SELECT_BIN"
 
 # Invoke Task 3 health check script
 echo "=== Running toolchain health checks ==="
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-if [ -f "$SCRIPT_DIR/check_toolchain.sh" ]; then
-    CHECK_TOOLCHAIN_PATH="$SCRIPT_DIR/check_toolchain.sh"
-else
-    CHECK_TOOLCHAIN_PATH="$SCRIPT_DIR/../ci/check_toolchain.sh"
-fi
 bash "$CHECK_TOOLCHAIN_PATH" "$AAPT2_BIN" "$SPLIT_SELECT_BIN"
 
 # Calculate target directory


### PR DESCRIPTION
Addresses post-merge cleanup feedback: performs check_toolchain.sh existence check at the very beginning of setup_modern_tools.sh script execution, fail-fasting with clear error output before doing any heavy download tasks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install-script-only change that avoids wasted downloads; no runtime app or security impact.
> 
> **Overview**
> **Fail-fast toolchain helper check** in `setup_modern_tools.sh`: `check_toolchain.sh` is resolved at startup (right after the `7z` prerequisite check), instead of only after the SDK download and extract.
> 
> If the helper is missing from both `scripts/install/` and `scripts/ci/`, the script now exits immediately with a clear error instead of running the heavy wget/7z workflow and failing later at the health-check step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6faacef614ab3cd4368098cf17247bcc6a2b497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->